### PR TITLE
chore: Use latest as default when building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ on:
       version:
         description: 'Version:'
         required: true
-        default: '30.0.0'
+        default: '31.0.9'
         type: string
       buildNumber:
         description: 'Build number:'


### PR DESCRIPTION
Bump to latest version